### PR TITLE
Gray encoding

### DIFF
--- a/src/gray/bin2gray.veryl
+++ b/src/gray/bin2gray.veryl
@@ -3,10 +3,10 @@
 /// Time Complexity: O(1)
 pub module bin2gray #(
     /// Input and output bit vector width
-    parameter WIDTH: u32 = 32,
+    param WIDTH: u32 = 32,
 ) (
     /// Input Binary encoded Bit Vector
-    i_bin : input  logic<WIDTH>,
+    i_bin: input logic<WIDTH>,
     /// Output Gray encoded Bit Vector
     o_gray: output logic<WIDTH>,
 ) {

--- a/src/gray/bin2gray.veryl
+++ b/src/gray/bin2gray.veryl
@@ -1,8 +1,14 @@
+/// Converts a binary encoded bit vector to a Gray encoded bit-vector
+/// Space Complexity: O(WIDTH)
+/// Time Complexity: O(1)
 pub module bin2gray #(
-  param WIDTH: u32 = 32,
+    /// Input and output bit vector width
+    parameter WIDTH: u32 = 32,
 ) (
-  i_bin: input logic<WIDTH>,
-  o_gray: output logic<WIDTH>,
+    /// Input Binary encoded Bit Vector
+    i_bin : input  logic<WIDTH>,
+    /// Output Gray encoded Bit Vector
+    o_gray: output logic<WIDTH>,
 ) {
-  assign o_gray = i_bin ^ (i_bin >> 1);
+    assign o_gray = i_bin ^ (i_bin >> 1);
 }

--- a/src/gray/bin2gray.veryl
+++ b/src/gray/bin2gray.veryl
@@ -1,0 +1,8 @@
+pub module bin2gray #(
+  param WIDTH: u32 = 32,
+) (
+  i_bin: input logic<WIDTH>,
+  o_gray: output logic<WIDTH>,
+) {
+  assign o_gray = i_bin ^ (i_bin >> 1);
+}

--- a/src/gray/gray2bin.veryl
+++ b/src/gray/gray2bin.veryl
@@ -1,34 +1,46 @@
-/// Converts a Gray-encoded bit vector to a binary encoded bit-vector
+/// Converts a Gray encoded bit vector to a binary encoded bit-vector
+/// Space Complexity: O(WIDTH log WIDTH)
+/// Time Complexity: O(log WIDTH)
 pub module gray2bin #(
-  /// Input and output bit vector width
-  param WIDTH: u32 = 1,
+    /// Input and output bit vector width
+    parameter WIDTH: u32 = 1,
 ) (
-  /// Input Bit Vecotr
-  i_val : input logic<WIDTH>,
-  /// Output Bit Vector such that
-  /// o_val[k] = ^o_val[WIDTH-1:k]
-  o_val : output logic<WIDTH>,
+    /// Input Gray encoded Bit Vector
+    i_gray: input logic<WIDTH>,
+    /// Output binary encoded Bit Vector such that
+    /// o_bin[k] = ^o_bin[WIDTH-1:k]
+    o_bin: output logic<WIDTH>,
 ) {
-  if WIDTH == 1 : g_base {
-    assign o_val = i_val;
-  } else {
-    local BWIDTH: u32 = WIDTH / 2;
-    local TWIDTH: u32 = WIDTH - BWIDTH;
+    if WIDTH == 1 :g_base {
+        assign o_bin = i_gray;
+    } else {
+        localparam BWIDTH: u32 = WIDTH / 2;
+        localparam TWIDTH: u32 = WIDTH - BWIDTH;
 
-    // Top Bits
-    let top_in: logic<TWIDTH> = i_val[WIDTH-1:BWIDTH];
-    var top_out: logic<TWIDTH>;
+        // Top Bits
+        let top_in : logic<TWIDTH> = i_gray[WIDTH - 1:BWIDTH];
+        var top_out: logic<TWIDTH>;
 
-    inst u_top: gray2bin #(WIDTH: TWIDTH) (i_val: top_in, o_val: top_out);
+        inst u_top: gray2bin #(
+            WIDTH : TWIDTH ,
+        ) (
+            i_gray: top_in ,
+            o_bin : top_out,
+        );
 
-    // Bot Bits
-    let bot_in: logic<BWIDTH> = i_val[BWIDTH-1:0];
-    var bot_out: logic<BWIDTH>;
-    // Have to xor all of the bottom bits with the xor-reduction of the top bits
-    let bot_red: logic<BWIDTH> = bot_out ^ {top_out[0] repeat BWIDTH};
+        // Bot Bits
+        let bot_in : logic<BWIDTH> = i_gray[BWIDTH - 1:0];
+        var bot_out: logic<BWIDTH>;
+        // Have to xor all of the bottom bits with the xor-reduction of the top bits
+        let bot_red: logic<BWIDTH> = bot_out ^ {top_out[0] repeat BWIDTH};
 
-    inst u_bot: gray2bin #(WIDTH: BWIDTH) (i_val: bot_in, o_val: bot_out);
+        inst u_bot: gray2bin #(
+            WIDTH : BWIDTH ,
+        ) (
+            i_gray: bot_in ,
+            o_bin : bot_out,
+        );
 
-    assign o_val = {top_out, bot_red};
-  }
+        assign o_bin = {top_out, bot_red};
+    }
 }

--- a/src/gray/gray2bin.veryl
+++ b/src/gray/gray2bin.veryl
@@ -3,7 +3,7 @@
 /// Time Complexity: O(log WIDTH)
 pub module gray2bin #(
     /// Input and output bit vector width
-    parameter WIDTH: u32 = 1,
+    param WIDTH: u32 = 1,
 ) (
     /// Input Gray encoded Bit Vector
     i_gray: input logic<WIDTH>,
@@ -14,15 +14,15 @@ pub module gray2bin #(
     if WIDTH == 1 :g_base {
         assign o_bin = i_gray;
     } else {
-        localparam BWIDTH: u32 = WIDTH / 2;
-        localparam TWIDTH: u32 = WIDTH - BWIDTH;
+        local BWIDTH: u32 = WIDTH / 2;
+        local TWIDTH: u32 = WIDTH - BWIDTH;
 
         // Top Bits
         let top_in : logic<TWIDTH> = i_gray[WIDTH - 1:BWIDTH];
         var top_out: logic<TWIDTH>;
 
         inst u_top: gray2bin #(
-            WIDTH : TWIDTH ,
+            WIDTH: TWIDTH,
         ) (
             i_gray: top_in ,
             o_bin : top_out,
@@ -35,7 +35,7 @@ pub module gray2bin #(
         let bot_red: logic<BWIDTH> = bot_out ^ {top_out[0] repeat BWIDTH};
 
         inst u_bot: gray2bin #(
-            WIDTH : BWIDTH ,
+            WIDTH: BWIDTH,
         ) (
             i_gray: bot_in ,
             o_bin : bot_out,

--- a/src/gray/gray2bin.veryl
+++ b/src/gray/gray2bin.veryl
@@ -1,0 +1,34 @@
+/// Converts a Gray-encoded bit vector to a binary encoded bit-vector
+pub module gray2bin #(
+  /// Input and output bit vector width
+  param WIDTH: u32 = 1,
+) (
+  /// Input Bit Vecotr
+  i_val : input logic<WIDTH>,
+  /// Output Bit Vector such that
+  /// o_val[k] = ^o_val[WIDTH-1:k]
+  o_val : output logic<WIDTH>,
+) {
+  if WIDTH == 1 : g_base {
+    assign o_val = i_val;
+  } else {
+    local BWIDTH: u32 = WIDTH / 2;
+    local TWIDTH: u32 = WIDTH - BWIDTH;
+
+    // Top Bits
+    let top_in: logic<TWIDTH> = i_val[WIDTH-1:BWIDTH];
+    var top_out: logic<TWIDTH>;
+
+    inst u_top: gray2bin #(WIDTH: TWIDTH) (i_val: top_in, o_val: top_out);
+
+    // Bot Bits
+    let bot_in: logic<BWIDTH> = i_val[BWIDTH-1:0];
+    var bot_out: logic<BWIDTH>;
+    // Have to xor all of the bottom bits with the xor-reduction of the top bits
+    let bot_red: logic<BWIDTH> = bot_out ^ {top_out[0] repeat BWIDTH};
+
+    inst u_bot: gray2bin #(WIDTH: BWIDTH) (i_val: bot_in, o_val: bot_out);
+
+    assign o_val = {top_out, bot_red};
+  }
+}

--- a/src/gray/gray_counter.veryl
+++ b/src/gray/gray_counter.veryl
@@ -58,13 +58,13 @@ pub module gray_counter #(
     );
 
     inst u_gray_cur: bin2gray #(
-        WIDTH                 ,
+        WIDTH  ,
     ) (
-        i_bin : bin_count     ,
-        o_gray: o_count       ,
+        i_bin : bin_count,
+        o_gray: o_count  ,
     );
     inst u_gray_next: bin2gray #(
-        WIDTH                 ,
+        WIDTH  ,
     ) (
         i_bin : bin_count_next,
         o_gray: o_count_next  ,

--- a/src/gray/gray_counter.veryl
+++ b/src/gray/gray_counter.veryl
@@ -1,0 +1,73 @@
+/// Value counter using Gray Encoding
+pub module gray_counter #(
+    /// Counter width
+    param WIDTH: u32 = 2,
+    /// Max value of counter (in binary)
+    param MAX_COUNT: bit<WIDTH> = '1,
+    /// Min value of counter (in binary)
+    param MIN_COUNT: bit<WIDTH> = '0,
+    /// Initial value of counter (in binary)
+    param INITIAL_COUNT: bit<WIDTH> = MIN_COUNT,
+    /// Whether counter is wrap around
+    param WRAP_AROUND: bit = 1,
+    /// Counter type
+    local COUNT: type = logic<WIDTH>,
+) (
+    /// Clock
+    i_clk: input logic,
+    /// Reset
+    i_rst: input logic,
+    /// Clear counter
+    i_clear: input logic,
+    /// Set counter to a value
+    i_set: input logic,
+    /// Value used by i_set
+    i_set_value: input COUNT,
+    /// Count up
+    i_up: input logic,
+    /// Count down
+    i_down: input logic,
+    /// Count value
+    o_count: output COUNT,
+    /// Count value for the next clock cycle
+    o_count_next: output COUNT,
+    /// Indicator for wrap around
+    o_wrap_around: output logic,
+) {
+
+    var bin_count     : COUNT;
+    var bin_count_next: COUNT;
+
+    inst u_bin_counter: counter #(
+        WIDTH          ,
+        MAX_COUNT      ,
+        MIN_COUNT      ,
+        INITIAL_COUNT  ,
+        WRAP_AROUND    ,
+    ) (
+        i_clk                        ,
+        i_rst                        ,
+        i_clear                      ,
+        i_set                        ,
+        i_set_value                  ,
+        i_up                         ,
+        i_down                       ,
+        o_count      : bin_count     ,
+        o_count_next : bin_count_next,
+        o_wrap_around                ,
+    );
+
+    inst u_gray_cur: bin2gray #(
+        WIDTH                 ,
+    ) (
+        i_bin : bin_count     ,
+        o_gray: o_count       ,
+    );
+    inst u_gray_next: bin2gray #(
+        WIDTH                 ,
+    ) (
+        i_bin : bin_count_next,
+        o_gray: o_count_next  ,
+    );
+
+}

--- a/testbench/gray/gray_bench.sv
+++ b/testbench/gray/gray_bench.sv
@@ -1,0 +1,28 @@
+module gray_bench;
+  localparam WIDTH = 32;
+  logic [WIDTH-1:0] i_bin;
+  logic [WIDTH-1:0] o_gray;
+  logic [WIDTH-1:0] o_bin;
+  logic [WIDTH-1:0] g_bin;
+
+  always_comb begin
+    g_bin = '0;
+    for (int i = 0; i < WIDTH; ++i) begin
+      g_bin ^= o_gray >> i;
+    end
+  end
+
+  std_bin2gray #(WIDTH) dut2(.i_bin, .o_gray);
+  std_gray2bin #(WIDTH) dut1(.i_gray(o_gray), .o_bin);
+
+  initial begin
+    for (longint i = 0; i < (1 << WIDTH); ++i) begin
+      i_bin = i;
+      #1;
+      assert(o_bin == g_bin);
+      assert(i_bin == o_bin);
+      #1;
+    end
+  end
+
+endmodule


### PR DESCRIPTION
This provides two modules for Gray encodings.

`gray2bin` converts a bitvector of length `WIDTH` to a binary encoding from a Gray encoding.

`bin2gray` converts a bitvector of length `WIDTH` to a Gray encoding from a binary encoding.

These modules are a prerequisite for an async FIFO, and are also used in communications applications.

I have tested these for bitvectors of length 24 and am currently running simulations for length 32.